### PR TITLE
chore: update Maciej and Sergio owned repositories list

### DIFF
--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -190,13 +190,17 @@
 			"asyncapi-react",
 			"chatbot",
 			"cli",
+			"converter-go",
+			"event-gateway",
 			"generator-react-sdk",
 			"generator",
 			"html-template",
 			"markdown-template",
 			"modelina",
 			"parser-js",
+			"parser-go",
 			"playground",
+			"template-for-go-projects",
 			"website"
 		]
 	},
@@ -255,10 +259,13 @@
 		"availableForHire": false,
 		"company": "Postman",
 		"repos": [
+			"converter-go",
 			"event-gateway",
 			"go-watermill-template",
 			"infra",
-			"parser-api"
+			"parser-api",
+			"server-api",
+			"template-for-go-projects"
 		]
 	},
 	{


### PR DESCRIPTION
**Description**

This PR adds some of the latest repos owned by @magicmatatjahu and @smoya to the list on the TSC members page.

- https://github.com/asyncapi/server-api/pull/18
- https://github.com/asyncapi/parser-go/pull/100
- https://github.com/asyncapi/event-gateway/pull/90
- https://github.com/asyncapi/converter-go/pull/63
- https://github.com/asyncapi/template-for-go-projects/pull/29

