### PR TITLE
ci: remove fmvilas from alternative hosts list

### DIFF
--- a/.github/workflows/create-event-ad-hoc.yml
+++ b/.github/workflows/create-event-ad-hoc.yml
@@ -30,7 +30,7 @@ jobs:
       meeting_desc: ${{ github.event.inputs.desc }}
       meeting_banner: ${{ github.event.inputs.meeting_banner }}
       host: lpgornicki@gmail.com
-      alternative_host: "fmvilas@gmail.com,jonas-lt@live.dk,devlopergene@gmail.com,sibanda.thulie@gmail.com,alejandra.olvera.novack@gmail.com,samir.amzani@gmail.com"
+      alternative_host: "jonas-lt@live.dk,devlopergene@gmail.com,sibanda.thulie@gmail.com,alejandra.olvera.novack@gmail.com,samir.amzani@gmail.com"
       issue_template_path: .github/workflows/create-event-helpers/issues_templates/ad-hoc.md
       create_zoom: true
     secrets:


### PR DESCRIPTION
**Description**

Fran shared he is not actually organising meetings atm so better to remove him from alternative hosts.

**Related issue(s)**
Fixes https://github.com/asyncapi/community/actions/runs/9566927143/job/26373495416#step:6:23