### PR TITLE
docs: clarify jurisdiction of the CoC Committee regarding Slack external connections

### DIFF
--- a/code_of_conduct/coc-incident-resolution-procedures.md
+++ b/code_of_conduct/coc-incident-resolution-procedures.md
@@ -76,7 +76,7 @@ Once the report has been submitted, the AsyncAPI CoC Committee will confirm rece
 
 The Jurisdiction of the CoC Committee is as follows:
 - [AsyncAPI Initiative GitHub](https://github.com/asyncapi)
-- [AsyncAPI Slack](asyncapi.slack.com)
+- [AsyncAPI Slack](asyncapi.slack.com), including all external channels connected through [Slack Connect](https://slack.com/connect).
 - AsyncAPI social networks: [Twitter](https://twitter.com/AsyncAPISpec), [LinkedIn](https://www.linkedin.com/company/asyncapi), [YouTube](https://www.youtube.com/asyncapi), [Twitch](https://www.twitch.tv/asyncapi), and [Mastodon](https://fosstodon.org/@AsyncAPISpec)
 - AsyncAPI events: conferences, talks, workshops, etc.
 


### PR DESCRIPTION
**Description**

[Slack Connect](https://slack.com/connect) allows other Slack Workspaces to connect some channels into other Workspaces, in this case AsyncAPI. 
An example is the [#jsonschema](https://asyncapi.slack.com/archives/C038FTU4LQ6) channel in AsyncAPI Slack Workspace.

Since there can be confusion about the jurisdiction of the CoC Committee, this PR is an attempt to clarify it.
The idea is that CoC should be enforced in those external channels as well, since they are visible in AsyncAPI Slack Workspace.